### PR TITLE
TPUz Metrics through new protobuff definitions

### DIFF
--- a/tpu_info/tpu_info/proto/tpu_metric_service.proto
+++ b/tpu_info/tpu_info/proto/tpu_metric_service.proto
@@ -3,17 +3,16 @@ syntax = "proto3";
 package tpu.monitoring.runtime;
 
 import "google/protobuf/timestamp.proto";
+import "tpu_info/proto/tpu_telemetry.proto";
 
-
-
+option java_package = "com.google.tpu.monitoring.runtime.service.proto";
 option java_multiple_files = true;
 option objc_class_prefix = "GRPC";
-option java_package = "com.google.tpu.monitoring.runtime.service.proto";
 
 
 message Exemplar {
   double value = 1;
-  .google.protobuf.Timestamp timestamp = 2;
+  google.protobuf.Timestamp timestamp = 2;
   repeated Attribute attributes = 3;
 }
 
@@ -175,6 +174,12 @@ message Attribute {
 // A metric has a reporting time, attribute and a measure value.
 message Metric {
   Attribute attribute = 1;
+  // The start_timestamp is the timestamp of the start of the metric collection
+  // interval. The timestamp is the timestamp of the last time the metric value
+  // is updated. Cumulative counter metrics need to be exported to monarch in
+  // the form of intervals with the same start timestamp and increasing end
+  // timestamps. start_timestamp is only set for cumulative metrics.
+  .google.protobuf.Timestamp start_timestamp = 7;
   .google.protobuf.Timestamp timestamp = 2;
   oneof measure {
     Gauge gauge = 3;
@@ -183,6 +188,7 @@ message Metric {
     Summary summary = 6;
   }
 }
+
 
 // TPUMetric is a standalone metric object, exposed externally to a consumer.
 message TPUMetric {
@@ -207,8 +213,8 @@ message MetricRequest {
 }
 
 // MetricResponse is the response object for RuntimeService.GetRuntimeMetric.
-// The response contains the TPUMetric as response which holds the metric data
-// for the requested metric.
+// The response is for single metric request and contains either a TPUMetric or
+// metric.
 message MetricResponse {
   TPUMetric metric = 1;
 }
@@ -239,6 +245,19 @@ message ListSupportedMetricsResponse {
   repeated SupportedMetric supported_metric = 1;
 }
 
+message GetTpuRuntimeStatusRequest {
+  // If true, the response will include HLO information for each core.
+  bool include_hlo_info = 1;
+}
+
+message GetTpuRuntimeStatusResponse {
+  optional string host_name = 1;
+  // Map from a unique Global Core ID to the state of that core.
+  map<int32,
+      tpu_telemetry.CurrentCoreStateSummary>
+      core_states = 2;
+}
+
 service RuntimeMetricService {
   // GetRuntimeMetric returns the TPU metrics data for the MetricRequest.
   rpc GetRuntimeMetric(MetricRequest) returns (MetricResponse);
@@ -247,4 +266,10 @@ service RuntimeMetricService {
   // ListSupportedMetricsRequest.
   rpc ListSupportedMetrics(ListSupportedMetricsRequest)
       returns (ListSupportedMetricsResponse);
+
+  // GetTpuRuntimeStatus returns the TPU runtime status for the
+  // GetTpuRuntimeStatusRequest.
+  rpc GetTpuRuntimeStatus(GetTpuRuntimeStatusRequest)
+      returns (GetTpuRuntimeStatusResponse) {
+  }
 }

--- a/tpu_info/tpu_info/proto/tpu_telemetry.proto
+++ b/tpu_info/tpu_info/proto/tpu_telemetry.proto
@@ -1,275 +1,102 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 
-package tpu.monitoring.runtime;
+package tpu_telemetry;
 
-import "google/protobuf/timestamp.proto";
-import "tpu_info/proto/tpu_telemetry.proto";
-
-option java_package = "com.google.tpu.monitoring.runtime.service.proto";
-option java_multiple_files = true;
-option objc_class_prefix = "GRPC";
-
-
-message Exemplar {
-  double value = 1;
-  google.protobuf.Timestamp timestamp = 2;
-  repeated Attribute attributes = 3;
+// Duped from google3/learning/brain/tpu/runtime/tpu_chip_enums.proto
+// A protobuf mirror of the C++ TpuCoreType enum.
+enum TpuCoreTypeProto {
+  TPU_CORE_TYPE_INVALID = 0;
+  TPU_CORE_TYPE_TENSOR_CORE = 1;
+  TPU_CORE_TYPE_SPARSE_CORE_V0 = 2;
+  TPU_CORE_TYPE_SPARSE_CORE = 3;
 }
 
-message Distribution {
-  int64 count = 1;
-  double mean = 2;
-  double min = 3;
-  double max = 4;
-  double sum_of_squared_deviation = 5;
-
-  message BucketOptions {
-    oneof options {
-      Regular regular_buckets = 1 [deprecated = true];
-      Exponential exponential_buckets = 2;
-      Explicit explicit_buckets = 3;
-      Linear linear_buckets = 4;
-    }
-    message Regular {
-      option deprecated = true;
-
-      int32 num_finite_buckets = 1;
-      // A linear distribution has only one bound with overall width and offset
-      // of the lowest bucket.
-      // An explicit distribution will have monotonically increasing buckets
-      // with width and the offset from the previous bucket.
-      repeated Bound bounds = 2;
-    }
-    message Exponential {
-      // Must be greater than 0.
-      int32 num_finite_buckets = 1;
-      // Must be greater than 1.
-      double growth_factor = 2;
-      // Must be greater than 0.
-      double scale = 3;
-    }
-    message Bound {
-      option deprecated = true;
-
-      double width = 1;
-      double offset = 2;
-    }
-
-    // Specifies a linear sequence of buckets that all have the same width
-    // (except overflow and underflow). Each bucket represents a constant
-    // absolute uncertainty on the specific value in the bucket.
-    //
-    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
-    // following boundaries:
-    //
-    //    Upper bound (0 <= i < N-1):     offset + (width * i).
-    //
-    //    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
-    message Linear {
-      // Must be greater than 0.
-      int32 num_finite_buckets = 1;
-
-      // Must be greater than 0.
-      double width = 2;
-
-      // Lower bound of the first bucket.
-      double offset = 3;
-    }
-
-    // Specifies a set of buckets with arbitrary widths.
-    //
-    // There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
-    // boundaries:
-    //
-    //    Upper bound (0 <= i < N-1):     bounds[i]
-    //    Lower bound (1 <= i < N);       bounds[i - 1]
-    //
-    // The `bounds` field must contain at least one element. If `bounds` has
-    // only one element, then there are no finite buckets, and that single
-    // element is the common boundary of the overflow and underflow buckets.
-    message Explicit {
-      // The values must be monotonically increasing.
-      repeated double bounds = 1;
-    }
-  }
-
-  // Defines the histogram bucket boundaries.
-  BucketOptions bucket_options = 6;
-  repeated int64 bucket_counts = 7;
-  repeated Exemplar exemplars = 8;
+// Identifies a core within a chip.
+message TpuCoreOnChipProto {
+  optional TpuCoreTypeProto type = 1;
+  optional int32 index = 2;
 }
 
-// Gauge represents a single-point measure.
-message Gauge {
-  oneof value {
-    double as_double = 1;
-    int64 as_int = 2;
-    string as_string = 3;
-    bool as_bool = 4;
-  }
+// Duped from google3/learning/brain/tpu/runtime/tpu_chip_enums.proto
+// A protobuf mirror of the C++ TpuSequencerType enum.
+enum TpuSequencerTypeProto {
+  TPU_SEQUENCER_TYPE_INVALID = 0;
+  TPU_SEQUENCER_TYPE_TENSOR_CORE_SEQUENCER = 1;
+  TPU_SEQUENCER_TYPE_SPARSE_CORE_V0_SEQUENCER = 2;
+  TPU_SEQUENCER_TYPE_SPARSE_CORE_V0_ADDRESS_HANDLER = 3;
+  TPU_SEQUENCER_TYPE_SPARSE_CORE_SEQUENCER = 4;
+  TPU_SEQUENCER_TYPE_SPARSE_CORE_TILE_ACCESS_CORE_SEQUENCER = 5;
+  TPU_SEQUENCER_TYPE_SPARSE_CORE_TILE_EXECUTE_CORE_SEQUENCER = 6;
 }
 
-// Counter is a monotonically increasing measure (until reset to zero).
-message Counter {
-  // The value MUST not be negative.
-  oneof value {
-    double as_double = 1;
-    uint64 as_int = 2;
-  }
-  Exemplar exemplar = 3;
+// Uniquely identifies a single core within a TPU system.
+message TpuCoreIdentifier {
+  optional int32 global_core_id = 1;
+  optional int32 chip_id = 2;
+  optional TpuCoreOnChipProto core_on_chip = 3;
 }
 
-// Quantile represents the value at a given quantile of a distribution.
-message Quantile {
-  // The quantile of a distribution. Must be in the interval [0.0, 1.0].
-  double quantile = 1;
-  // The value at the given quantile of a distribution.
-  // Quantile values must NOT be negative.
-  double value = 2;
+// Information about a program that is queued for execution on a core.
+message QueuedProgramInfo {
+  optional int64 run_id = 1;
+  optional int64 launch_id = 2;
+  optional bytes program_fingerprint = 3;
 }
 
-// Summary represents observed sampling for different quantiles including
-// sum of all the observations and total count of observations.
-message Summary {
-  uint64 sample_count = 1;
-  double sample_sum = 2;
-  repeated Quantile quantile = 3;
+// Information about the state of a single sequencer on a core.
+message SequencerInfo {
+  // The type of the sequencer.
+  optional TpuSequencerTypeProto sequencer_type = 1;
+  // The index of the sequencer on the core.
+  optional int32 sequencer_index = 2;
+  // The current program counter (PC) value.
+  optional int64 pc = 3;
+  // The current tag value.
+  optional int64 tag = 4;
+  // The current tracemark value.
+  optional int64 tracemark = 5;
+  // The ID of the program currently being executed.
+  optional int64 program_id = 6;
+  // The run ID of the current execution.
+  optional int64 run_id = 7;
+  // A string representation of the high-level symbolic location (e.g., HLO
+  // operation name and source line) corresponding to the current PC.
+  optional string hlo_location = 8;
+  // Additional formatted details about the HLO instruction, often including
+  // the full HLO instruction string and other context. The return format is a
+  // JSON array.
+  optional string hlo_detailed_info = 9;
 }
 
-// AttrValue represents an attribute value.
-// AttrValue is considered to be "empty" if all values are unspecified.
-message AttrValue {
-  oneof attr {
-    string string_attr = 1;
-    bool bool_attr = 2;
-    int64 int_attr = 3;
-    double double_attr = 4;
-    ArrayAttrValue array_attr = 5;
-    KeyValueList kvlist_attr = 6;
-    bytes bytes_attr = 7;
-  }
+// A summary of the current state of a single TPU core.
+message CurrentCoreStateSummary {
+  optional TpuCoreIdentifier core_id = 1;
+  repeated SequencerInfo sequencer_info = 2;
+  optional bool xdb_server_running = 3;
+  optional bytes program_fingerprint = 4;
+  optional int32 launch_id = 5;
+  repeated QueuedProgramInfo queued_program_info = 6;
+
+  // Detailed error message if any.
+  optional string error_message = 7;
 }
 
-// ArrayAttrValue is a list of AttrValue messages.
-message ArrayAttrValue {
-  // Array of attribute. The array may be empty (contain 0 elements).
-  repeated AttrValue attrs = 1;
-}
-
-// KeyValueList is a list of Key-AttrValue messages.
-message KeyValueList {
-  // A collection of key/value attributes. The list may be empty.
-  // The keys in attributes MUST be unique.
-  repeated Attribute attributes = 1;
-}
-
-// Attribute is a key-value pair to store the attributes of a metric.
-// For example, device-id of the metric, host-id of the metric.
-message Attribute {
-  string key = 1;
-  AttrValue value = 2;
-}
-
-// Metric represents a metric datapoint.
-// A metric has a reporting time, attribute and a measure value.
-message Metric {
-  Attribute attribute = 1;
-  // The start_timestamp is the timestamp of the start of the metric collection
-  // interval. The timestamp is the timestamp of the last time the metric value
-  // is updated. Cumulative counter metrics need to be exported to monarch in
-  // the form of intervals with the same start timestamp and increasing end
-  // timestamps. start_timestamp is only set for cumulative metrics.
-  .google.protobuf.Timestamp start_timestamp = 7;
-  .google.protobuf.Timestamp timestamp = 2;
-  oneof measure {
-    Gauge gauge = 3;
-    Counter counter = 4;
-    Distribution distribution = 5;
-    Summary summary = 6;
-  }
-}
-
-
-// TPUMetric is a standalone metric object, exposed externally to a consumer.
-message TPUMetric {
-  string name = 1;
-  string description = 2;
-  repeated Metric metrics = 3;
-}
-
-// MetricRequest is the request object to fetch metrics from LibTPU.
-// MetricRequest contains the metric name with which metrics can be fetched
-// from the RuntimeMetricsService.GetRuntimeMetric.
-message MetricRequest {
-  string metric_name = 1;
-  // skip_node_aggregation provides options to the client to skip aggregated
-  // lookup of metrics for a worker node. If the field is unset or set as false,
-  // an aggregated view of metrics for a TPU worker node would be provided.
-  // The aggregation feature is enabled by libTPU during initialization.
-  // By default, the worker node aggregation would be turned on in libTPU if the
-  // metrics server is supported. If the libTPU initialization turns off the
-  // feature explicitly, then the aggregated view would not be provided.
-  bool skip_node_aggregation = 2;
-}
-
-// MetricResponse is the response object for RuntimeService.GetRuntimeMetric.
-// The response is for single metric request and contains either a TPUMetric or
-// metric.
-message MetricResponse {
-  TPUMetric metric = 1;
-}
-
-// ListSupportedMetricsRequest is the request object for
-// RuntimeService.ListSupportedMetrics.
-// Empty request means no filters. All the metrics supported from the LibTPU
-// would be returned as the response.
-message ListSupportedMetricsRequest {
-  // A regex filter to apply to the supported metrics.
-  // If the field is empty or not set, no filter is applied. All the supported
-  // metrics are returned.
-  //
-  // Example: `.*memory.*`, `.*memory.*|.*duty_cycle.*`
-  string filter = 1;
-}
-
-message SupportedMetric {
-  string metric_name = 1;
-}
-
-// ListSupportedMetricsResponse is the response object for
-// RuntimeService.ListSupportedMetrics.
-// It contains all the metrics supported in the LibTPU for the
-// ListSupportedMetricsRequest.
-message ListSupportedMetricsResponse {
-  // List of supported metric.
-  repeated SupportedMetric supported_metric = 1;
-}
-
-message GetTpuRuntimeStatusRequest {
-  // If true, the response will include HLO information for each core.
-  bool include_hlo_info = 1;
-}
-
-message GetTpuRuntimeStatusResponse {
-  optional string host_name = 1;
+// A collection of state summaries for all cores in a system.
+message AllCoreStateSummaries {
   // Map from a unique Global Core ID to the state of that core.
-  map<int32,
-      tpu_telemetry.CurrentCoreStateSummary>
-      core_states = 2;
-}
-
-service RuntimeMetricService {
-  // GetRuntimeMetric returns the TPU metrics data for the MetricRequest.
-  rpc GetRuntimeMetric(MetricRequest) returns (MetricResponse);
-
-  // ListSupportedMetrics lists the supported metrics for
-  // ListSupportedMetricsRequest.
-  rpc ListSupportedMetrics(ListSupportedMetricsRequest)
-      returns (ListSupportedMetricsResponse);
-
-  // GetTpuRuntimeStatus returns the TPU runtime status for the
-  // GetTpuRuntimeStatusRequest.
-  rpc GetTpuRuntimeStatus(GetTpuRuntimeStatusRequest)
-      returns (GetTpuRuntimeStatusResponse) {
-  }
+  map<int32, CurrentCoreStateSummary> core_states = 1;
 }

--- a/tpu_info/tpu_info/proto/tpu_telemetry.proto
+++ b/tpu_info/tpu_info/proto/tpu_telemetry.proto
@@ -1,0 +1,275 @@
+syntax = "proto3";
+
+package tpu.monitoring.runtime;
+
+import "google/protobuf/timestamp.proto";
+import "tpu_info/proto/tpu_telemetry.proto";
+
+option java_package = "com.google.tpu.monitoring.runtime.service.proto";
+option java_multiple_files = true;
+option objc_class_prefix = "GRPC";
+
+
+message Exemplar {
+  double value = 1;
+  google.protobuf.Timestamp timestamp = 2;
+  repeated Attribute attributes = 3;
+}
+
+message Distribution {
+  int64 count = 1;
+  double mean = 2;
+  double min = 3;
+  double max = 4;
+  double sum_of_squared_deviation = 5;
+
+  message BucketOptions {
+    oneof options {
+      Regular regular_buckets = 1 [deprecated = true];
+      Exponential exponential_buckets = 2;
+      Explicit explicit_buckets = 3;
+      Linear linear_buckets = 4;
+    }
+    message Regular {
+      option deprecated = true;
+
+      int32 num_finite_buckets = 1;
+      // A linear distribution has only one bound with overall width and offset
+      // of the lowest bucket.
+      // An explicit distribution will have monotonically increasing buckets
+      // with width and the offset from the previous bucket.
+      repeated Bound bounds = 2;
+    }
+    message Exponential {
+      // Must be greater than 0.
+      int32 num_finite_buckets = 1;
+      // Must be greater than 1.
+      double growth_factor = 2;
+      // Must be greater than 0.
+      double scale = 3;
+    }
+    message Bound {
+      option deprecated = true;
+
+      double width = 1;
+      double offset = 2;
+    }
+
+    // Specifies a linear sequence of buckets that all have the same width
+    // (except overflow and underflow). Each bucket represents a constant
+    // absolute uncertainty on the specific value in the bucket.
+    //
+    // There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
+    // following boundaries:
+    //
+    //    Upper bound (0 <= i < N-1):     offset + (width * i).
+    //
+    //    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
+    message Linear {
+      // Must be greater than 0.
+      int32 num_finite_buckets = 1;
+
+      // Must be greater than 0.
+      double width = 2;
+
+      // Lower bound of the first bucket.
+      double offset = 3;
+    }
+
+    // Specifies a set of buckets with arbitrary widths.
+    //
+    // There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
+    // boundaries:
+    //
+    //    Upper bound (0 <= i < N-1):     bounds[i]
+    //    Lower bound (1 <= i < N);       bounds[i - 1]
+    //
+    // The `bounds` field must contain at least one element. If `bounds` has
+    // only one element, then there are no finite buckets, and that single
+    // element is the common boundary of the overflow and underflow buckets.
+    message Explicit {
+      // The values must be monotonically increasing.
+      repeated double bounds = 1;
+    }
+  }
+
+  // Defines the histogram bucket boundaries.
+  BucketOptions bucket_options = 6;
+  repeated int64 bucket_counts = 7;
+  repeated Exemplar exemplars = 8;
+}
+
+// Gauge represents a single-point measure.
+message Gauge {
+  oneof value {
+    double as_double = 1;
+    int64 as_int = 2;
+    string as_string = 3;
+    bool as_bool = 4;
+  }
+}
+
+// Counter is a monotonically increasing measure (until reset to zero).
+message Counter {
+  // The value MUST not be negative.
+  oneof value {
+    double as_double = 1;
+    uint64 as_int = 2;
+  }
+  Exemplar exemplar = 3;
+}
+
+// Quantile represents the value at a given quantile of a distribution.
+message Quantile {
+  // The quantile of a distribution. Must be in the interval [0.0, 1.0].
+  double quantile = 1;
+  // The value at the given quantile of a distribution.
+  // Quantile values must NOT be negative.
+  double value = 2;
+}
+
+// Summary represents observed sampling for different quantiles including
+// sum of all the observations and total count of observations.
+message Summary {
+  uint64 sample_count = 1;
+  double sample_sum = 2;
+  repeated Quantile quantile = 3;
+}
+
+// AttrValue represents an attribute value.
+// AttrValue is considered to be "empty" if all values are unspecified.
+message AttrValue {
+  oneof attr {
+    string string_attr = 1;
+    bool bool_attr = 2;
+    int64 int_attr = 3;
+    double double_attr = 4;
+    ArrayAttrValue array_attr = 5;
+    KeyValueList kvlist_attr = 6;
+    bytes bytes_attr = 7;
+  }
+}
+
+// ArrayAttrValue is a list of AttrValue messages.
+message ArrayAttrValue {
+  // Array of attribute. The array may be empty (contain 0 elements).
+  repeated AttrValue attrs = 1;
+}
+
+// KeyValueList is a list of Key-AttrValue messages.
+message KeyValueList {
+  // A collection of key/value attributes. The list may be empty.
+  // The keys in attributes MUST be unique.
+  repeated Attribute attributes = 1;
+}
+
+// Attribute is a key-value pair to store the attributes of a metric.
+// For example, device-id of the metric, host-id of the metric.
+message Attribute {
+  string key = 1;
+  AttrValue value = 2;
+}
+
+// Metric represents a metric datapoint.
+// A metric has a reporting time, attribute and a measure value.
+message Metric {
+  Attribute attribute = 1;
+  // The start_timestamp is the timestamp of the start of the metric collection
+  // interval. The timestamp is the timestamp of the last time the metric value
+  // is updated. Cumulative counter metrics need to be exported to monarch in
+  // the form of intervals with the same start timestamp and increasing end
+  // timestamps. start_timestamp is only set for cumulative metrics.
+  .google.protobuf.Timestamp start_timestamp = 7;
+  .google.protobuf.Timestamp timestamp = 2;
+  oneof measure {
+    Gauge gauge = 3;
+    Counter counter = 4;
+    Distribution distribution = 5;
+    Summary summary = 6;
+  }
+}
+
+
+// TPUMetric is a standalone metric object, exposed externally to a consumer.
+message TPUMetric {
+  string name = 1;
+  string description = 2;
+  repeated Metric metrics = 3;
+}
+
+// MetricRequest is the request object to fetch metrics from LibTPU.
+// MetricRequest contains the metric name with which metrics can be fetched
+// from the RuntimeMetricsService.GetRuntimeMetric.
+message MetricRequest {
+  string metric_name = 1;
+  // skip_node_aggregation provides options to the client to skip aggregated
+  // lookup of metrics for a worker node. If the field is unset or set as false,
+  // an aggregated view of metrics for a TPU worker node would be provided.
+  // The aggregation feature is enabled by libTPU during initialization.
+  // By default, the worker node aggregation would be turned on in libTPU if the
+  // metrics server is supported. If the libTPU initialization turns off the
+  // feature explicitly, then the aggregated view would not be provided.
+  bool skip_node_aggregation = 2;
+}
+
+// MetricResponse is the response object for RuntimeService.GetRuntimeMetric.
+// The response is for single metric request and contains either a TPUMetric or
+// metric.
+message MetricResponse {
+  TPUMetric metric = 1;
+}
+
+// ListSupportedMetricsRequest is the request object for
+// RuntimeService.ListSupportedMetrics.
+// Empty request means no filters. All the metrics supported from the LibTPU
+// would be returned as the response.
+message ListSupportedMetricsRequest {
+  // A regex filter to apply to the supported metrics.
+  // If the field is empty or not set, no filter is applied. All the supported
+  // metrics are returned.
+  //
+  // Example: `.*memory.*`, `.*memory.*|.*duty_cycle.*`
+  string filter = 1;
+}
+
+message SupportedMetric {
+  string metric_name = 1;
+}
+
+// ListSupportedMetricsResponse is the response object for
+// RuntimeService.ListSupportedMetrics.
+// It contains all the metrics supported in the LibTPU for the
+// ListSupportedMetricsRequest.
+message ListSupportedMetricsResponse {
+  // List of supported metric.
+  repeated SupportedMetric supported_metric = 1;
+}
+
+message GetTpuRuntimeStatusRequest {
+  // If true, the response will include HLO information for each core.
+  bool include_hlo_info = 1;
+}
+
+message GetTpuRuntimeStatusResponse {
+  optional string host_name = 1;
+  // Map from a unique Global Core ID to the state of that core.
+  map<int32,
+      tpu_telemetry.CurrentCoreStateSummary>
+      core_states = 2;
+}
+
+service RuntimeMetricService {
+  // GetRuntimeMetric returns the TPU metrics data for the MetricRequest.
+  rpc GetRuntimeMetric(MetricRequest) returns (MetricResponse);
+
+  // ListSupportedMetrics lists the supported metrics for
+  // ListSupportedMetricsRequest.
+  rpc ListSupportedMetrics(ListSupportedMetricsRequest)
+      returns (ListSupportedMetricsResponse);
+
+  // GetTpuRuntimeStatus returns the TPU runtime status for the
+  // GetTpuRuntimeStatusRequest.
+  rpc GetTpuRuntimeStatus(GetTpuRuntimeStatusRequest)
+      returns (GetTpuRuntimeStatusResponse) {
+  }
+}


### PR DESCRIPTION
Update existing protobuff `tpu_metric_service.proto` and added new protobuff `tpu_telemetry.proto` to support TPUz metrics available in `tpu-info==0.7.0`